### PR TITLE
Fix mistakes in freeing SDL2 objects.

### DIFF
--- a/sdl2.vapi
+++ b/sdl2.vapi
@@ -1455,7 +1455,7 @@ namespace SDL {
 		public delegate int BlitFunc (Graphics.Surface src, Graphics.Rect? srcrect,
 		  Graphics.Surface dst, Graphics.Rect? dstrect);
 	
-		[CCode (type_id="SDL_Surface", cname="SDL_Surface", free_function="SDL_FreeSurface", 	cheader_filename="SDL2/SDL_surface.h")]
+		[CCode (type_id="SDL_Surface", cname="SDL_Surface", ref_function="SDL_Surface_up", unref_function="SDL_FreeSurface", 	cheader_filename="SDL2/SDL_surface.h")]
 		[Compact]
 		public class Surface {
 			public uint32 flags;

--- a/sdl2.vapi
+++ b/sdl2.vapi
@@ -1455,7 +1455,8 @@ namespace SDL {
 		public delegate int BlitFunc (Graphics.Surface src, Graphics.Rect? srcrect,
 		  Graphics.Surface dst, Graphics.Rect? dstrect);
 	
-		[CCode (type_id="SDL_Surface", cname="SDL_Surface", free_function="SDL_FreeSurface", 	cheader_filename="SDL2/SDL_surface.h", ref_function = "SDL_Surface_up", unref_function = 	"SDL_FreeSurface")]
+		[CCode (type_id="SDL_Surface", cname="SDL_Surface", free_function="SDL_FreeSurface", 	cheader_filename="SDL2/SDL_surface.h")]
+		[Compact]
 		public class Surface {
 			public uint32 flags;
 			public Graphics.PixelFormat format;
@@ -1616,7 +1617,7 @@ namespace SDL {
 			NONE, HORIZONTAL, VERTICAL
 		}// RendererFlip
 		
-		[CCode (cprefix="SDL_", cname = "SDL_Renderer", destroy_function = "SDL_DestroyTexture", cheader_filename="SDL2/SDL_render.h")]
+		[CCode (cprefix="SDL_", cname = "SDL_Renderer", free_function = "SDL_DestroyRenderer", cheader_filename="SDL2/SDL_render.h")]
 		[Compact]
 		public class Renderer {
 			[CCode (cname="SDL_GetNumRenderDrivers")]
@@ -1716,7 +1717,7 @@ namespace SDL {
 			public void present();
 		}// Renderer
 		
-		[CCode (cprefix="SDL_", cname = "SDL_Texture", destroy_function = "SDL_DestroyTexture", free_function="SDL_DestroyTexture", cheader_filename="SDL2/SDL_render.h")]
+		[CCode (cprefix="SDL_", cname = "SDL_Texture", free_function="SDL_DestroyTexture", cheader_filename="SDL2/SDL_render.h")]
 		[Compact]
 		public class Texture {
 			[CCode (cname="SDL_CreateTexture")]
@@ -1878,7 +1879,7 @@ namespace SDL {
 		public delegate HitTestResult HitTestFunc(Graphics.Window window, Graphics.Point area);
 		
 		
-		[CCode (cprefix="SDL_", cname = "SDL_Window", destroy_function = "SDL_DestroyWindow", cheader_filename="SDL2/SDL_video.h")]
+		[CCode (cprefix="SDL_", cname = "SDL_Window", free_function = "SDL_DestroyWindow", cheader_filename="SDL2/SDL_video.h")]
 		[Compact]
 		public class Window {
 			[CCode (cname="SDL_WINDOWPOS_UNDEFINED_MASK")]


### PR DESCRIPTION
  Problems:
    Surface: refers to an SDL_Surface_up function that does not
      exist.  Non-compact class.
    Renderer: refers to SDL_DestroyTexture, uses destroy_function
      but is a class.
    Window: uses destroy_function but is a class.
    Texture: uses destroy_function but is a class.

  Fixes:
    Surface: make compact, remove ref/unref.
    Renderer: destroy_function -> free_function, SDL_DestroyTexture
      -> SDL_DestroyRenderer
    Window: destroy_function -> free_function
    Texture: destroy_function -> free_function
