### PR TITLE
Fixing compilation errors

### DIFF
--- a/sdl2-ttf.vapi
+++ b/sdl2-ttf.vapi
@@ -130,7 +130,7 @@ namespace SDLTTF {
 		public int get_size_utf16 ([CCode (array_length = false)] uint16[] text, ref int w, ref int h);
 
 		[CCode (cname = "TTF_RenderText_Solid")]
-		public SDL.Video.Surface? render_latin1 ([CCode (array_length = false)]uint8[], SDL.Video.Color fg);
+		public SDL.Video.Surface? render_latin1 ([CCode (array_length = false)]uint8[] text, SDL.Video.Color fg);
 
 		[CCode (cname = "TTF_RenderUTF8_Solid")]
 		public SDL.Video.Surface? render (string text, SDL.Video.Color fg);

--- a/sdl2.vapi
+++ b/sdl2.vapi
@@ -2648,7 +2648,7 @@ namespace SDL {
 				size_t len;
 				uint8* raw = get_raw_state(out len);
 				unowned bool[] retval = (bool[])raw;
-				retval.length = len;
+				retval.length = (int)len;
 				return retval;
 			}
 
@@ -2821,7 +2821,7 @@ namespace SDL {
 			//Convenience method, use guid_buffer if the GUID is truncated here
 			public static string get_guid_string (Input.JoystickGUID guid) {
 				uint8[1024] buf;
-				guid_buffer (guid, out buf);
+				get_guid_buffer (guid, out buf);
 				return (string)buf;
 			}
 


### PR DESCRIPTION
Valac 0.32.1 was giving me some grief with a few errors in 2 of the vapis and was refusing to compile.

Summary of fixes:
- one implicit cast
- one unrecognized symbol (guid_buffer, was renamed but missed in refactor I assume)
- one missing identifier (in TTF vapi)
